### PR TITLE
Fix rust README.md

### DIFF
--- a/rust/README.md
+++ b/rust/README.md
@@ -12,8 +12,8 @@
 
 
 ![GitHub](https://img.shields.io/github/license/1yib/vsc-bundle?color=A3BE8C&style=flat-square)
-![Installs](https://vsmarketplacebadges.dev/installs-short/1YIB.python-bundle.svg?&logo=visualstudiocode&color=A3BE8C)
-![Version](https://vsmarketplacebadges.dev/version-short/1YiB.python-bundle.svg?&logo=visualstudiocode&color=A3BE8C&label=version)
+![Installs](https://vsmarketplacebadges.dev/installs-short/1YiB.rust-bundle.svg?&logo=visualstudiocode&color=A3BE8C)
+![Version](https://vsmarketplacebadges.dev/version-short/1YiB.rust-bundle.svg?&logo=visualstudiocode&color=A3BE8C&label=version)
 
 </div>
 
@@ -28,7 +28,7 @@
 |---|---|
 | `rust-lang.rust-analyzer` | ![Visual Studio Marketplace Installs](https://vsmarketplacebadges.dev/installs-short/rust-lang.rust-analyzer.svg?&logo=visualstudiocode&color=A3BE8C) |
 | `serayuzgur.crates` | ![Visual Studio Marketplace Installs](https://vsmarketplacebadges.dev/installs-short/serayuzgur.crates.svg?&logo=visualstudiocode&color=A3BE8C) |
-| `njpwerner.autodocstring` | ![Visual Studio Marketplace Installs](https://vsmarketplacebadges.dev/installs-short/njpwerner.autodocstring.svg?&logo=visualstudiocode&color=A3BE8C) |
+| `dustypomerleau.rust-syntax` | ![Visual Studio Marketplace Installs](https://vsmarketplacebadges.dev/installs-short/dustypomerleau.rust-syntax.svg?&logo=visualstudiocode&color=A3BE8C) |
 
 
 <br />


### PR DESCRIPTION
Remove njpwerner.autodocstring, which isn't included in this bundle, add dustypomerleau.rust-syntax, which is.

Fix badges that were referring to the python bundle.